### PR TITLE
Fixed two bugs

### DIFF
--- a/phaser/phaser.py
+++ b/phaser/phaser.py
@@ -1065,7 +1065,10 @@ def call_mapping_script(input):
 	mapping_result = tempfile.NamedTemporaryFile(delete=False);
 	mapping_result.close();
 	
-	subprocess.call("samtools view -h "+bam+" "+chrom+": | samtools view -Sh "+samtools_arg+" -L "+bed_out+" -q "+mapq+" - | "+args.python_string+" "+return_script_path()+"/read_variant_map.py --baseq "+str(args.baseq)+" --splice 1 --isize_cutoff "+str(isize)+" --variant_table "+mapper_out+" --o "+mapping_result.name, stderr=devnull, stdout=devnull, shell=True);
+	#Save error code from subprocess if not 0, file it writes is truncated and gives unexpected wrong results.
+	error_code = subprocess.call("samtools view -h "+bam+" "+chrom+": | samtools view -Sh "+samtools_arg+" -L "+bed_out+" -q "+mapq+" - | "+args.python_string+" "+return_script_path()+"/read_variant_map.py --baseq "+str(args.baseq)+" --splice 1 --isize_cutoff "+str(isize)+" --variant_table "+mapper_out+" --o "+mapping_result.name, stderr=devnull, stdout=devnull, shell=True);
+	if error_code != 0:
+		raise RuntimeError("subprocess.call of read_variant_map.py exited with an error")
 		
 	fun_flush_print("               completed chromosome %s..."%(chrom));
 	return(mapping_result.name);

--- a/phaser/read_variant_map.py
+++ b/phaser/read_variant_map.py
@@ -67,7 +67,9 @@ def main():
 							as_column = i;
 				else:
 					alignment_score = int(read_columns[as_column].split(":")[2]);
-					
+				
+				#Set as_column back to initial value, in case not all reads have equal number fields
+				as_column = -1;
 		
 				# BAM and variant not on same chromosome
 				if line_variant != None:


### PR DESCRIPTION
- Raise error when subprocess call to variant mapper fails. Before, when read_variant_map.py exited with error the output file was truncated and phASER used this truncated file for further analysis.
- Prevent variant mapper from using wrong field for AS. When reads have a different number of fields, the  AS field is set using the index from the first read. Now for each read the index position of the AS field is searched, instead of assuming this index position is always the same for all reads.