### PR TITLE
Fix: Parse AS tag only when string starts with "AS:"

### DIFF
--- a/phaser/read_variant_map.py
+++ b/phaser/read_variant_map.py
@@ -62,7 +62,7 @@ def main():
 		
 				if as_column == -1:
 					for i in range(11,len(read_columns)):
-						if "AS:" in read_columns[i]:
+						if read_columns[i].startswith("AS:"):
 							alignment_score = int(read_columns[i].split(":")[2]);
 							as_column = i;
 				else:


### PR DESCRIPTION
I have a BAM file (Genome in a Bottle data) where there are some extra tags added to each record that seem to encode quality values of some type. Some of these quality strings actually contain the string `AS:` just by chance. Without this fix, phaser mistakenly recognizes that quality tag as the one for the alignment score and crashes when it tries to intepret the part after it as an integer.